### PR TITLE
Add test setup with Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@types/node": "^22.10.1",
@@ -30,6 +31,10 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.6",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.5.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",

--- a/src/__tests__/filterNotes.test.tsx
+++ b/src/__tests__/filterNotes.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from '../App';
+
+describe('App filtering', () => {
+  test('filters notes by progress', () => {
+    render(<App />);
+
+    // open filter dropdown and choose Completed
+    const filterButton = screen.getByLabelText(/filter notes/i);
+    fireEvent.click(filterButton);
+    fireEvent.click(screen.getByText(/Completed/i));
+
+    expect(screen.queryByText('Machine Learning')).toBeNull();
+    expect(screen.getByText('Introduction to Python')).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(4);
+  });
+
+  test('filters by progress and search term', () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search notes/i), {
+      target: { value: 'Machine' }
+    });
+
+    const filterButton = screen.getByLabelText(/filter notes/i);
+    fireEvent.click(filterButton);
+    fireEvent.click(screen.getByText(/In Progress/i));
+
+    expect(screen.getByText('Machine Learning')).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,10 @@ export default defineConfig({
       }
     }
   },
-  publicDir: 'public'
+  publicDir: 'public',
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts'
+  }
 });


### PR DESCRIPTION
## Summary
- add Vitest config in `vite.config.ts`
- add vitest and testing-library packages to `package.json`
- create `setupTests.ts` for jest-dom utilities
- add an initial test covering the filtering logic in `App`

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b94b592f0832d91bcc96c8c736ba7